### PR TITLE
Added support for DUPLICATE_POLICY / ON_DUPLICATE keywords ( TS.INFO update accordingly )

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -56,7 +56,7 @@ jobs:
           name: run tests
           command: |
             . venv/bin/activate
-            REDIS_PORT=6379 coverage run -m pytest -v test_commands.py
+            REDIS_PORT=6379 coverage run test_commands.py
 
       - run:
           name: codecove
@@ -97,7 +97,7 @@ jobs:
           name: run tests
           command: |
             . venv/bin/activate
-            REDIS_PORT=6379 pytest -v test_commands.py
+            REDIS_PORT=6379 python test_commands.py
 
   build_edge:
     docker:
@@ -132,7 +132,7 @@ jobs:
           name: run tests
           command: |
             . venv/bin/activate
-            REDIS_PORT=6379 pytest -v test_commands.py
+            REDIS_PORT=6379 python test_commands.py
 
       # no need for store_artifacts on nightly builds 
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -56,10 +56,8 @@ jobs:
           name: run tests
           command: |
             . venv/bin/activate
-            REDIS_PORT=6379 coverage run test_commands.py
+            REDIS_PORT=6379 coverage run -m pytest -v test_commands.py
 
-      - early_return_for_forked_pull_requests
-       
       - run:
           name: codecove
           command: |
@@ -99,7 +97,7 @@ jobs:
           name: run tests
           command: |
             . venv/bin/activate
-            REDIS_PORT=6379 python test_commands.py
+            REDIS_PORT=6379 pytest -v test_commands.py
 
   build_edge:
     docker:
@@ -134,7 +132,7 @@ jobs:
           name: run tests
           command: |
             . venv/bin/activate
-            REDIS_PORT=6379 python test_commands.py
+            REDIS_PORT=6379 pytest -v test_commands.py
 
       # no need for store_artifacts on nightly builds 
 


### PR DESCRIPTION
Fixes #65 
- This PR follows the [General Availability release for RedisTimeSeries 1.4](https://github.com/RedisTimeSeries/RedisTimeSeries/releases/tag/v1.4.5) and the ability to back-fill time series.
- It also also moves towards making usage of keyword variadic arguments on touched functions just to make the code cleaner and less error prone. 
- Apart from it, it enables coverage to be run on forked PR ( given that we want to know coverage diffs on community PRs as well ). 