### PR TITLE
Automatically publish packages on testpypi and pypi uppon new tags

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -99,7 +99,7 @@ jobs:
       - persist_to_workspace:
           # Must be an absolute path, or relative path from working_directory. This is a directory on the container which is 
           # taken to be the root directory of the workspace.
-          root: /home/circleci
+          root: .
           # Must be relative path from root
           paths:
             - dist-<< parameters.python_version >>
@@ -116,7 +116,7 @@ jobs:
     steps:
       - attach_workspace:
           # Must be absolute path or relative path from working_directory
-          at: /home/circleci
+          at: .
 
       - run: |
           if [ -d dist-<< parameters.python_version >> ]; then

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,6 +36,7 @@ commands:
             . venv/bin/activate
             pip install -r requirements.txt
             pip install codecov
+            pip install wheel
 
       - save_cache:
           paths:
@@ -43,8 +44,12 @@ commands:
           key: v1-dependencies-<<parameters.python_version>>-{{ checksum "requirements.txt" }}
 
       - run:
-          name: test dist
+          name: Create a source distribution
           command: python setup.py sdist
+
+      - run:
+          name: Create a wheel
+          command: python setup.py bdist_wheel
 
       - run:
           name: run tests
@@ -57,7 +62,7 @@ executors:
     parameters:
       python_version:
         description: "python version tag"
-        default: "3.7.1"
+        default: "3.6"
         type: string
       redistimeseries_version:
         default: "edge"
@@ -90,6 +95,37 @@ jobs:
               . venv/bin/activate
               codecov
             fi
+      # Persist the specified paths (dist-<< parameters.python_version >>) into the workspace for use in downstream job. 
+      - persist_to_workspace:
+          # Must be an absolute path, or relative path from working_directory. This is a directory on the container which is 
+          # taken to be the root directory of the workspace.
+          root: ~/repo
+          # Must be relative path from root
+          paths:
+            - dist-<< parameters.python_version >>
+  
+  publish-release-pypi:
+    parameters:
+      python_version:
+        default: "2.7"
+        type: string
+    executor:
+      name: container_versions
+      python_version: <<parameters.python_version>>
+    working_directory: ~/repo
+    steps:
+      - attach_workspace:
+          # Must be absolute path or relative path from working_directory
+          at: ~/repo
+
+      - run: |
+          if [ -d dist-<< parameters.python_version >> ]; then
+            echo "It worked!";
+          else
+            echo "Nope!"; exit 1
+          fi
+
+    
 
 workflows:
   version: 2
@@ -105,7 +141,17 @@ workflows:
                 - '3.7'
                 - '3.8'
                 - '3.9.0rc2'
+            name: a
       - build
+      - publish-release-pypi:
+          requires:
+            - build-2.7
+          python_version: "2.7"
+          filters:
+            branches:
+              ignore: /.*/
+            tags:
+              only: /^\d+\.\d+\.\d+$/
 
   nightly:
     triggers:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -99,7 +99,7 @@ jobs:
       - persist_to_workspace:
           # Must be an absolute path, or relative path from working_directory. This is a directory on the container which is 
           # taken to be the root directory of the workspace.
-          root: ~/repo
+          root: /home/circleci
           # Must be relative path from root
           paths:
             - dist-<< parameters.python_version >>
@@ -116,7 +116,7 @@ jobs:
     steps:
       - attach_workspace:
           # Must be absolute path or relative path from working_directory
-          at: ~/repo
+          at: /home/circleci
 
       - run: |
           if [ -d dist-<< parameters.python_version >> ]; then

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -136,6 +136,11 @@ jobs:
           name: Upload with twine to Test PyPI
           command: twine upload -r testpypi dist-<< parameters.python_version >>/*
 
+      # Uncomment me after we've checked that all is working as expected on TestPyPi
+      # - run:
+      #     name: Upload with twine to PyPI
+      #     command: twine upload -r pypi dist-<< parameters.python_version >>/*
+
     
 
 workflows:
@@ -158,6 +163,7 @@ workflows:
           requires:
             - build-2.7
           python_version: "2.7"
+          # Enable the following lines after we've checked that all is working as expected on TestPyPi
           # filters:
           #   branches:
           #     ignore: /.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -95,11 +95,15 @@ jobs:
               . venv/bin/activate
               codecov
             fi
+      - run:
+          name: mv dist/* to dist-<<parameters.python_version>>
+          command: |
+            mv dist dist-<<parameters.python_version>>
       # Persist the specified paths (dist-<< parameters.python_version >>) into the workspace for use in downstream job. 
       - persist_to_workspace:
           # Must be an absolute path, or relative path from working_directory. This is a directory on the container which is 
           # taken to be the root directory of the workspace.
-          root: .
+          root: ~/repo
           # Must be relative path from root
           paths:
             - dist-<< parameters.python_version >>

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,22 +18,16 @@ commands:
               circleci step halt
             fi
 
-jobs:
-  build:
-    docker:
-      - image: circleci/python:3.7.1
-      - image: redislabs/redistimeseries:edge
-
-    working_directory: ~/repo
-
+  run-tests:
+    parameters:
+      python_version:
+        default: "3.6"
+        type: string
     steps:
       - checkout
-
       - restore_cache: # Download and cache dependencies
           keys:
-          - v1-dependencies-{{ checksum "requirements.txt" }}
-          # fallback to using the latest cache if no exact match is found
-          - v1-dependencies-
+            - v1-dependencies-<<parameters.python_version>>-{{ checksum "requirements.txt" }}
 
       - run:
           name: install dependencies
@@ -42,11 +36,11 @@ jobs:
             . venv/bin/activate
             pip install -r requirements.txt
             pip install codecov
-            
+
       - save_cache:
           paths:
             - ./venv
-          key: v1-dependencies-{{ checksum "requirements.txt" }}
+          key: v1-dependencies-<<parameters.python_version>>-{{ checksum "requirements.txt" }}
 
       - run:
           name: test dist
@@ -58,90 +52,61 @@ jobs:
             . venv/bin/activate
             REDIS_PORT=6379 coverage run test_commands.py
 
-      - run:
-          name: codecove
-          command: |
-            . venv/bin/activate
-            codecov
-
-  build_latest:
+executors:
+  container_versions: # declares a reusable python executor
+    parameters:
+      python_version:
+        description: "python version tag"
+        default: "3.7.1"
+        type: string
+      redistimeseries_version:
+        default: "edge"
+        type: string
     docker:
-      - image: circleci/python:3.7.1
-      - image: redislabs/redistimeseries:latest
+      - image: circleci/python:<<parameters.python_version>>
+      - image: redislabs/redistimeseries:<<parameters.redistimeseries_version>>
 
+jobs:
+  build:
+    parameters:
+      python_version:
+        default: "3.6"
+        type: string
+      redistimeseries_version:
+        default: "edge"
+        type: string
+    executor:
+      name: container_versions
+      python_version: <<parameters.python_version>>
+      redistimeseries_version: <<parameters.redistimeseries_version>>
     working_directory: ~/repo
-
     steps:
-      - checkout
-
-      - restore_cache: # Download and cache dependencies
-          keys:
-            - v1-dependencies-{{ checksum "requirements.txt" }}
-            # fallback to using the latest cache if no exact match is found
-            - v1-dependencies-
-
+      - run-tests:
+        python_version: << parameters.python_version >>
       - run:
-          name: install dependencies
+          name: Run Coverage only for Python3.6
           command: |
-            virtualenv venv
-            . venv/bin/activate
-            pip install -r requirements.txt
-            pip install codecov
-
-      - save_cache:
-          paths:
-            - ./venv
-          key: v1-dependencies-{{ checksum "requirements.txt" }}
-
-      - run:
-          name: run tests
-          command: |
-            . venv/bin/activate
-            REDIS_PORT=6379 python test_commands.py
-
-  build_edge:
-    docker:
-      - image: circleci/python:3.7.1
-      - image: redislabs/redistimeseries:edge
-
-    working_directory: ~/repo
-
-    steps:
-      - checkout
-
-      - restore_cache: # Download and cache dependencies
-          keys:
-          - v1-dependencies-{{ checksum "requirements.txt" }}
-          # fallback to using the latest cache if no exact match is found
-          - v1-dependencies-
-
-      - run:
-          name: install dependencies
-          command: |
-            virtualenv venv
-            . venv/bin/activate
-            pip install -r requirements.txt
-            pip install codecov
-            
-      - save_cache:
-          paths:
-            - ./venv
-          key: v1-dependencies-{{ checksum "requirements.txt" }}
-
-      - run:
-          name: run tests
-          command: |
-            . venv/bin/activate
-            REDIS_PORT=6379 python test_commands.py
-
-      # no need for store_artifacts on nightly builds 
+            if [ <<parameters.python_version>> = "3.6" ]; then
+              . venv/bin/activate
+              codecov
+            fi
 
 workflows:
   version: 2
   commit:
     jobs:
+      - build:
+          matrix:
+            parameters:
+              python_version:
+                - '2.7'
+                - '3.4'
+                - '3.5'
+                - '3.7'
+                - '3.8'
+                - '3.9.0rc2'
       - build
-      - build_latest
+
   nightly:
     triggers:
       - schedule:
@@ -151,5 +116,14 @@ workflows:
               only:
                 - master
     jobs:
-      - build_edge
-      - build_latest
+      - build:
+          matrix:
+            parameters:
+              python_version:
+                - '2.7'
+                - '3.4'
+                - '3.5'
+                - '3.6'
+                - '3.7'
+                - '3.8'
+                - '3.9.0rc2'

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -99,6 +99,7 @@ jobs:
           name: mv dist/* to dist-<<parameters.python_version>>
           command: |
             mv dist dist-<<parameters.python_version>>
+
       # Persist the specified paths (dist-<< parameters.python_version >>) into the workspace for use in downstream job. 
       - persist_to_workspace:
           # Must be an absolute path, or relative path from working_directory. This is a directory on the container which is 
@@ -122,12 +123,18 @@ jobs:
           # Must be absolute path or relative path from working_directory
           at: .
 
-      - run: |
-          if [ -d dist-<< parameters.python_version >> ]; then
-            echo "It worked!";
-          else
-            echo "Nope!"; exit 1
-          fi
+      - run:
+          name: Install twine
+          command: pip install twine
+
+      - run:
+          name: Create a .pypirc
+          command: |
+            echo -e "[pypi]\nusername = __token__\npassword = $PYPI_TOKEN\n\n[testpypi]\nusername = __token__\npassword = $TESTPYPI_TOKEN\n" >> .pypirc
+
+      - run:
+          name: Upload with twine to Test PyPI
+          command: twine upload -r testpypi dist-<< parameters.python_version >>/*
 
     
 
@@ -151,11 +158,11 @@ workflows:
           requires:
             - build-2.7
           python_version: "2.7"
-          filters:
-            branches:
-              ignore: /.*/
-            tags:
-              only: /^\d+\.\d+\.\d+$/
+          # filters:
+          #   branches:
+          #     ignore: /.*/
+          #   tags:
+          #     only: /^\d+\.\d+\.\d+$/
 
   nightly:
     triggers:

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ requirements = list(map(str.strip, open("requirements.txt").readlines()))
 
 setup(
     name='redistimeseries',
-    version='0.8.0',
+    version="1.4.0",
     description='RedisTimeSeries Python Client',
     long_description=read_all("README.md"),
     long_description_content_type='text/markdown',
@@ -19,7 +19,10 @@ setup(
     classifiers=[
         'Intended Audience :: Developers',
         'License :: OSI Approved :: BSD License',
+        'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
+        'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3.6',
         'Topic :: Database',
         'Topic :: Software Development :: Testing'
     ],


### PR DESCRIPTION
@rafie for now this is a draft that requires `PYPI_TOKEN` and `TESTPYPI_TOKEN` to be present as secrets on circleci. 
The PyPI part is commented and only TestPyPi is enabled. After we check all is working as expected on TestPyPI we can enable PyPI and also enable the filter on tagged versions. 
WDYT @rafie ?  