### PR TITLE
Using github actions to publish to PyPi

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -108,44 +108,6 @@ jobs:
           # Must be relative path from root
           paths:
             - dist-<< parameters.python_version >>
-  
-  publish-release-pypi:
-    parameters:
-      python_version:
-        default: "2.7"
-        type: string
-    executor:
-      name: container_versions
-      python_version: <<parameters.python_version>>
-    working_directory: ~/repo
-    steps:
-      - attach_workspace:
-          # Must be absolute path or relative path from working_directory
-          at: .
-
-      - run:
-          name: Install twine
-          command: pip install twine
-
-      - run:
-          name: Create a .pypirc
-          command: |
-            echo -e "[pypi]" >> ~/.pypirc
-            echo -e "username = __token__" >> ~/.pypirc
-            echo -e "password = $PYPI_TOKEN" >> ~/.pypirc
-            echo -e "[testpypi]" >> ~/.pypirc
-            echo -e "username = __token__" >> ~/.pypirc
-            echo -e "password = $TESTPYPI_TOKEN" >> ~/.pypirc
-
-      - run:
-          name: Upload with twine to Test PyPI
-          command: twine upload --skip-existing -r testpypi dist-<< parameters.python_version >>/*
-
-      - run:
-          name: Upload with twine to PyPI
-          command: twine upload -r pypi dist-<< parameters.python_version >>/*
-
-    
 
 workflows:
   version: 2
@@ -161,19 +123,10 @@ workflows:
                 - '3.7'
                 - '3.8'
                 - '3.9.0rc2'
-            filters:  # required since `publish-release-pypi` has tag filters AND requires `build`
+            filters:
               tags:
                 only: /.*/
       - build
-      - publish-release-pypi:
-          requires:
-            - build-2.7
-          python_version: "2.7"
-          filters:
-           tags:
-             only: /^v.*/
-           branches:
-             ignore: /.*/
 
   nightly:
     triggers:

--- a/.github/release-drafter-config.yml
+++ b/.github/release-drafter-config.yml
@@ -1,4 +1,4 @@
-name-template: 'Version $NEXT_PATCH_VERSION🌈'
+name-template: 'Version $NEXT_PATCH_VERSION'
 tag-template: 'v$NEXT_PATCH_VERSION'
 categories:
   - title: '🚀Features'
@@ -10,7 +10,7 @@ categories:
       - 'fix'
       - 'bugfix'
       - 'bug'
-  - title: '🧰Maintenance'
+  - title: 'Maintenance'
     label: 'chore'
 change-template: '- $TITLE @$AUTHOR (#$NUMBER)'
 exclude-labels:

--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -1,0 +1,46 @@
+name: Publish Pypi
+on:
+  release:
+    types: [published]
+
+jobs:
+  publish:
+    name: publish
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@master
+      - name: Set up Python 2.7
+        uses: actions/setup-python@v1
+        with:
+          python-version: 2.7
+
+      - name: Install twine
+          run: |
+            pip install twine
+
+      - name: Create a source distribution
+        run: |
+          python setup.py sdist
+
+      - name: Create a wheel
+          run: |
+            python setup.py bdist_wheel
+
+      - name: Create a .pypirc
+          run: |
+            echo -e "[pypi]" >> ~/.pypirc
+            echo -e "username = __token__" >> ~/.pypirc
+            echo -e "password = $PYPI_TOKEN" >> ~/.pypirc
+            echo -e "[testpypi]" >> ~/.pypirc
+            echo -e "username = __token__" >> ~/.pypirc
+            echo -e "password = $TESTPYPI_TOKEN" >> ~/.pypirc
+
+      - name: Publish to Test PyPI
+        if: github.event_name == 'release'
+        run: |
+          twine upload --skip-existing -r testpypi
+
+      - name: Publish to PyPI
+          if: github.event_name == 'release'
+          run: |
+            twine upload -r pypi

--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -18,6 +18,10 @@ jobs:
         run: |
             pip install twine
 
+      - name: Install wheel
+        run: |
+            pip install wheel
+
       - name: Create a source distribution
         run: |
           python setup.py sdist
@@ -30,17 +34,17 @@ jobs:
         run: |
             echo -e "[pypi]" >> ~/.pypirc
             echo -e "username = __token__" >> ~/.pypirc
-            echo -e "password = $PYPI_TOKEN" >> ~/.pypirc
+            echo -e "password = ${{ secrets.PYPI_TOKEN }}" >> ~/.pypirc
             echo -e "[testpypi]" >> ~/.pypirc
             echo -e "username = __token__" >> ~/.pypirc
-            echo -e "password = $TESTPYPI_TOKEN" >> ~/.pypirc
+            echo -e "password = ${{ secrets.TESTPYPI_TOKEN }}" >> ~/.pypirc
 
       - name: Publish to Test PyPI
         if: github.event_name == 'release'
         run: |
-          twine upload --skip-existing -r testpypi
+          twine upload --skip-existing -r testpypi dist/*
 
       - name: Publish to PyPI
         if: github.event_name == 'release'
         run: |
-          twine upload -r pypi
+          twine upload -r pypi dist/*

--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -15,7 +15,7 @@ jobs:
           python-version: 2.7
 
       - name: Install twine
-          run: |
+        run: |
             pip install twine
 
       - name: Create a source distribution
@@ -23,11 +23,11 @@ jobs:
           python setup.py sdist
 
       - name: Create a wheel
-          run: |
+        run: |
             python setup.py bdist_wheel
 
       - name: Create a .pypirc
-          run: |
+        run: |
             echo -e "[pypi]" >> ~/.pypirc
             echo -e "username = __token__" >> ~/.pypirc
             echo -e "password = $PYPI_TOKEN" >> ~/.pypirc
@@ -41,6 +41,6 @@ jobs:
           twine upload --skip-existing -r testpypi
 
       - name: Publish to PyPI
-          if: github.event_name == 'release'
-          run: |
-            twine upload -r pypi
+        if: github.event_name == 'release'
+        run: |
+          twine upload -r pypi

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 __pycache__/
 *.py[cod]
 *$py.class
+.idea/
 
 # C extensions
 *.so


### PR DESCRIPTION
This PR simplifies the release using github actions instead of circleci. 
@gkorland @rafie I've revised this is working as expected on the following dummy project ( it's redistimeseries with a different name only ): 
https://github.com/filipecosta90/test-release-rts-py
With the following release [v1.4.7](https://github.com/filipecosta90/test-release-rts-py/releases/tag/v1.4.7) being published on test.pypi and pypi:
- https://test.pypi.org/project/test-release-rts-py/1.4.7/
- https://pypi.org/project/test-release-rts-py/1.4.7/
. 
Action that published:
https://github.com/filipecosta90/test-release-rts-py/runs/1241437684?check_suite_focus=true