### PR TITLE
Included a check for the required secrets to publish to Pypi

### DIFF
--- a/.github/workflows/check-pypi.yml
+++ b/.github/workflows/check-pypi.yml
@@ -1,0 +1,26 @@
+name: Check if required secrets are set to publish to Pypi
+
+on: push
+
+jobs:
+  checksecret:
+    name: check if PYPI_TOKEN and TESTPYPI_TOKEN are set in github secrets
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check TESTPYPI_TOKEN
+        env:
+          TESTPYPI_TOKEN: ${{ secrets.TESTPYPI_TOKEN }}
+        run: |
+          if ${{ env.TESTPYPI_TOKEN == '' }} ; then
+            echo "TESTPYPI_TOKEN secret is not set"
+            exit 1
+          fi
+      - name: Check PYPI_TOKEN
+        env:
+          PYPI_TOKEN: ${{ secrets.PYPI_TOKEN }}
+        run: |
+          if ${{ env.PYPI_TOKEN == '' }} ; then
+            echo "PYPI_TOKEN secret is not set"
+            exit 1
+          fi
+

--- a/.github/workflows/check-pypi.yml
+++ b/.github/workflows/check-pypi.yml
@@ -7,14 +7,6 @@ jobs:
     name: check if PYPI_TOKEN and TESTPYPI_TOKEN are set in github secrets
     runs-on: ubuntu-latest
     steps:
-      - name: Check TESTPYPI_TOKEN
-        env:
-          TESTPYPI_TOKEN: ${{ secrets.TESTPYPI_TOKEN }}
-        run: |
-          if ${{ env.TESTPYPI_TOKEN == '' }} ; then
-            echo "TESTPYPI_TOKEN secret is not set"
-            exit 1
-          fi
       - name: Check PYPI_TOKEN
         env:
           PYPI_TOKEN: ${{ secrets.PYPI_TOKEN }}
@@ -23,4 +15,13 @@ jobs:
             echo "PYPI_TOKEN secret is not set"
             exit 1
           fi
+      - name: Check TESTPYPI_TOKEN
+        env:
+          TESTPYPI_TOKEN: ${{ secrets.TESTPYPI_TOKEN }}
+        run: |
+          if ${{ env.TESTPYPI_TOKEN == '' }} ; then
+            echo "TESTPYPI_TOKEN secret is not set"
+            exit 1
+          fi
+
 


### PR DESCRIPTION
This is a simple check to ensure that the secrets that we're required to have for publishing the packages are set on the repo. 
@gkorland and @rafie as you can see, what's causing the failure to publish to PyPi are the missing secrets. wdyt?