### PR TITLE
Add and expose at runtime in a standard format the __version__ attribute

### DIFF
--- a/redistimeseries/__init__.py
+++ b/redistimeseries/__init__.py
@@ -1,0 +1,1 @@
+from ._version import __version__

--- a/redistimeseries/_version.py
+++ b/redistimeseries/_version.py
@@ -1,0 +1,4 @@
+
+# This attribute is the only one place that the version number is written down,
+# so there is only one place to change it when the version number changes.
+__version__ = "1.4.3"

--- a/setup.py
+++ b/setup.py
@@ -5,11 +5,28 @@ def read_all(f):
     with io.open(f, encoding="utf-8") as I:
         return I.read()
 
+def read_version(version_file):
+    """
+    Given the input version_file, this function extracts the
+    version info from the __version__ attribute.
+    """
+    version_str = None
+    import re
+    verstrline = open(version_file, "rt").read()
+    VSRE = r"^__version__ = ['\"]([^'\"]*)['\"]"
+    mo = re.search(VSRE, verstrline, re.M)
+    if mo:
+        version_str = mo.group(1)
+    else:
+        raise RuntimeError("Unable to find version string in %s." % (version_file,))
+    return version_str
+
+
 requirements = list(map(str.strip, open("requirements.txt").readlines()))
 
 setup(
     name='redistimeseries',
-    version="1.4.3",
+    version=read_version("redistimeseries/_version.py"),
     description='RedisTimeSeries Python Client',
     long_description=read_all("README.md"),
     long_description_content_type='text/markdown',

--- a/test_commands.py
+++ b/test_commands.py
@@ -21,9 +21,12 @@ class RedisTimeSeriesTest(TestCase):
                 if module_info[1] == b'timeseries':
                     version = int(module_info[3])
 
+    def testVersionRuntime(self):
+        import redistimeseries as rts_pkg
+        self.assertNotEqual("",rts_pkg.__version__)
+
     def testCreate(self):
         '''Test TS.CREATE calls'''
-
         self.assertTrue(rts.create(1))
         self.assertTrue(rts.create(2, retention_msecs=5))
         self.assertTrue(rts.create(3, labels={'Redis':'Labs'}))


### PR DESCRIPTION
This is a simple PR to expose the package version at runtime. 
Here's a discussion on how to standardize this info: https://stackoverflow.com/questions/458550/standard-way-to-embed-version-into-python-package